### PR TITLE
[VEGA-4682]: Update consta/uikit and hilight table rows with Resources type.

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "@apollo/client": "^3.3.11",
-    "@consta/uikit": "3.9.3",
+    "@consta/uikit": "3.11.0",
     "@gpn-prototypes/vega-ui": "3.3.1",
     "@graphql-codegen/cli": "2.2.0",
     "@graphql-codegen/introspection": "2.1.0",

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.css
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.css
@@ -28,7 +28,7 @@
     border-left: 0 !important;
   }
 
-  ._lightBackground {
+  ._light-background {
     background-color: var(--color-bg-stripe);
   }
 }

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.css
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.css
@@ -20,15 +20,15 @@
     color: var(--color-typo-primary);
   }
 
-  .TableCell_lightBackground {
-    background-color: rgb(60, 64, 67);
-  }
-
   ._all {
     font-weight: 600;
   }
 
   ._no-right-border {
     border-left: 0 !important;
+  }
+
+  ._lightBackground {
+    background-color: var(--color-bg-stripe);
   }
 }

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.css
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.css
@@ -20,6 +20,10 @@
     color: var(--color-typo-primary);
   }
 
+  .TableCell_oddBackground {
+    background-color: rgb(60, 64, 67);
+  }
+
   ._all {
     font-weight: 600;
   }

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.css
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.css
@@ -20,7 +20,7 @@
     color: var(--color-typo-primary);
   }
 
-  .TableCell_oddBackground {
+  .TableCell_lightBackground {
     background-color: rgb(60, 64, 67);
   }
 

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
@@ -395,7 +395,11 @@ export const TableResultRb: React.FC<Props> = ({
         stickyHeader
         isResizable
         getAdditionalClassName={({ column, row, isActive }) => {
-          return row.GEO_CATEGORY?.value === 'Ресурсы' && !column.mergeCells && !isActive ? 'TableCell_oddBackground' : '';
+          return row.GEO_CATEGORY?.value === 'Ресурсы' &&
+            !column.mergeCells &&
+            !isActive
+            ? 'TableCell_lightBackground'
+            : '';
         }}
       />
 

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
@@ -384,7 +384,7 @@ export const TableResultRb: React.FC<Props> = ({
 
   const getAdditionalClassName = ({ column, row, isActive }): string => {
     return cn('TableCell', {
-      _lightBackground:
+      '_light-background':
         row.GEO_CATEGORY?.value === EGeoCategory.RESOURCES &&
         !column.mergeCells &&
         !isActive,

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { CustomContextMenu } from '@app/components/Helpers/ContextMenuHelper';
-import { EFluidType, EFluidTypeCode } from '@app/constants/Enums';
+import { EFluidType, EFluidTypeCode, EGeoCategory } from '@app/constants/Enums';
 import { RbDomainEntityInput } from '@app/generated/graphql';
 import { MenuContextItem } from '@app/interfaces/ContextMenuInterface';
 import {
@@ -18,6 +18,7 @@ import { IconAdd } from '@consta/uikit/IconAdd';
 import { IconRemove } from '@consta/uikit/IconRemove';
 import { Position } from '@consta/uikit/Popover';
 import { Table } from '@consta/uikit/Table';
+import cn from 'classnames';
 
 import { Column, RowEntity } from './types';
 
@@ -381,6 +382,15 @@ export const TableResultRb: React.FC<Props> = ({
     return false;
   };
 
+  const getAdditionalClassName = ({ column, row, isActive }): string => {
+    return cn('TableCell', {
+      _lightBackground:
+        row.GEO_CATEGORY?.value === EGeoCategory.RESOURCES &&
+        !column.mergeCells &&
+        !isActive,
+    });
+  };
+
   return (
     <div className="table">
       <Table
@@ -394,13 +404,7 @@ export const TableResultRb: React.FC<Props> = ({
         borderBetweenRows
         stickyHeader
         isResizable
-        getAdditionalClassName={({ column, row, isActive }) => {
-          return row.GEO_CATEGORY?.value === 'Ресурсы' &&
-            !column.mergeCells &&
-            !isActive
-            ? 'TableCell_lightBackground'
-            : '';
-        }}
+        getAdditionalClassName={getAdditionalClassName}
       />
 
       {visible && (

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
@@ -394,6 +394,9 @@ export const TableResultRb: React.FC<Props> = ({
         borderBetweenRows
         stickyHeader
         isResizable
+        getAdditionalClassName={({ column, row, isActive }) => {
+          return row.GEO_CATEGORY?.value === 'Ресурсы' && !column.mergeCells && !isActive ? 'TableCell_oddBackground' : '';
+        }}
       />
 
       {visible && (

--- a/src/constants/Enums.ts
+++ b/src/constants/Enums.ts
@@ -11,3 +11,8 @@ export const EFluidTypeCode = {
   [EFluidType.OIL_N_GAS]: 'MIXTURE',
   [EFluidType.ALL]: '',
 };
+
+export enum EGeoCategory {
+  RESOURCES = 'Ресурсы',
+  RESERVES = 'Запасы',
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1266,10 +1266,10 @@
     react-transition-group "^4.4.1"
     tslib "^1.13.0"
 
-"@consta/uikit@3.9.3":
-  version "3.9.3"
-  resolved "https://registry.yarnpkg.com/@consta/uikit/-/uikit-3.9.3.tgz#e0cf663385ecb70ec62dc4b6e29a840465b4a6d1"
-  integrity sha512-Yn3UfWqUC8Q1RZ2tb34ZB9Gv3uD0tC6WbEOgMgB6k65XVEjJwI2lc5h/LTw7tlIQu9Xi9RE6GSnT1QjPyfHx2A==
+"@consta/uikit@3.11.0":
+  version "3.11.0"
+  resolved "https://registry.yarnpkg.com/@consta/uikit/-/uikit-3.11.0.tgz#bde96b9f76786c11a43dc3dbe68934f372fed1a8"
+  integrity sha512-bRwMTpH861VS+2GE/jkNZpVLg1z9MAr2USErtdbmfaPmvDt99dpNsSkW2JNAwtOJ38ILJRlbqiiZ1JKphtIkSQ==
   dependencies:
     "@bem-react/classname" "^1.5.8"
     "@bem-react/classnames" "^1.3.9"
@@ -5423,21 +5423,6 @@ check-types@^8.0.3:
   resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
   integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
 
-"chokidar@>=3.0.0 <4.0.0", chokidar@^3.3.0, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
-  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
-
 chokidar@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -5472,6 +5457,21 @@ chokidar@^2.1.8:
     upath "^1.1.1"
   optionalDependencies:
     fsevents "^1.2.7"
+
+chokidar@^3.3.0, chokidar@^3.4.0, chokidar@^3.4.1, chokidar@^3.4.2, chokidar@^3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.2.tgz#dba3976fcadb016f66fd365021d91600d01c1e75"
+  integrity sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -8796,13 +8796,6 @@ globjoin@^0.1.4:
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
   integrity sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=
 
-gonzales-pe@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/gonzales-pe/-/gonzales-pe-4.3.0.tgz#fe9dec5f3c557eead09ff868c65826be54d067b3"
-  integrity sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==
-  dependencies:
-    minimist "^1.2.5"
-
 got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
@@ -11925,7 +11918,7 @@ negotiator@0.6.2:
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.2.tgz#feacf7ccf525a77ae9634436a64883ffeca346fb"
   integrity sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw==
 
-neo-async@^2.5.0, neo-async@^2.6.1, neo-async@^2.6.2:
+neo-async@^2.5.0, neo-async@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
@@ -13062,7 +13055,7 @@ postcss-value-parser@^4.1.0:
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz#443f6a20ced6481a2bda4fa8532a6e55d789a2cb"
   integrity sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==
 
-postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.21, postcss@^7.0.26, postcss@^7.0.31, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.36, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
+postcss@^7.0.0, postcss@^7.0.14, postcss@^7.0.17, postcss@^7.0.2, postcss@^7.0.26, postcss@^7.0.31, postcss@^7.0.32, postcss@^7.0.35, postcss@^7.0.36, postcss@^7.0.5, postcss@^7.0.6, postcss@^7.0.7:
   version "7.0.39"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-7.0.39.tgz#9624375d965630e2e1f2c02a935c82a59cb48309"
   integrity sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==
@@ -15280,6 +15273,8 @@ stylelint@^13.3.3, stylelint@^13.7.0:
     postcss-media-query-parser "^0.2.3"
     postcss-resolve-nested-selector "^0.1.1"
     postcss-safe-parser "^4.0.2"
+    postcss-sass "^0.4.4"
+    postcss-scss "^2.1.1"
     postcss-selector-parser "^6.0.5"
     postcss-syntax "^0.36.2"
     postcss-value-parser "^4.1.0"


### PR DESCRIPTION
## Problem statement

VEGA-4682 Нужно подсвечивать строки в таблице результатов расчета в зависимости от их типа (запасы - стандартный цвет, ресурсы - более светлый).

## Solution details

Было использовано свойство getAdditionalClassName компонента Table из новой версии библиотеки Consta.
Стенд: http://nd-4574-pwc-vega-builder.code013.org/

## Type

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

-

## Quality control

- [x] PR: Based on a correct branch
- [x] PR: Head branch is rebased on the base branch
- [ ] PR: Assignee chosen and necessary labels are set
- [ ] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [x] PR: Checked for spelling, grammar and typos
- [x] JS: There's no errors/warnings in the browser dev console
- [x] Layout: Tested with various content amounts
- [x] Docs: All the important changes and features are described
- [ ] Tests: Configuration files are checked at test repositories
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [ ] Tests: Existing unit tests passed successfully
- [ ] Tests: Existing E2E tests passed successfully
- [x] Tests: Manually tested on personal instance

## Notable statements
- [ ] Affects configuration files
- [x] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve
