### PR TITLE
Hide columns by default.

### DIFF
--- a/src/store/table/tableReducers.ts
+++ b/src/store/table/tableReducers.ts
@@ -28,6 +28,15 @@ const hiddenColumnsFromLocalStorage: HiddenColumns | null =
 
 export const DEFAULT_DECIMAL_FIXED = 3;
 
+export const getHiddenColumns = (): HiddenColumns => {
+  return Object.keys(hiddenColumnsFromLocalStorage).length !== 0
+    ? hiddenColumnsFromLocalStorage
+    : {
+        PERCENTILE: true,
+        GCOS: true,
+      };
+};
+
 export const tableInitialState: GridCollection = {
   columns: [],
   actualColumns: [],
@@ -37,8 +46,7 @@ export const tableInitialState: GridCollection = {
   sidebarRow: undefined,
   fluidType: EFluidType.ALL,
   decimalFixed: decimalFromLocalStorage !== null ? decimalFromLocalStorage : {},
-  hiddenColumns:
-    hiddenColumnsFromLocalStorage !== null ? hiddenColumnsFromLocalStorage : {},
+  hiddenColumns: getHiddenColumns(),
   entitiesCount: 0,
 };
 
@@ -138,11 +146,13 @@ export const TableReducers = reducerWithInitialState<GridCollection>(
   .case(
     TableActions.initState,
     (state: GridCollection, payload: GridCollection) => {
+      const initialHidenColumns = getHiddenColumns();
+
       return {
         ...state,
         rows: payload.rows,
         columns: payload.columns,
-        actualColumns: getActualColumns(payload),
+        actualColumns: getActualColumns(payload, initialHidenColumns),
         version: payload.version,
       };
     },


### PR DESCRIPTION
## Problem statement

https://artcpt.atlassian.net/browse/VEGA-4773
Сделать столбцы Подсчетных параметров и Рисков свёрнутыми по умолчанию (если ничего не задано в localstorage). 

## Solution details

Добавила признак сворачивания в initialState.
Стенд http://nd-4574-pwc-vega-builder.code013.org/

## Type

- [x] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

-

## Quality control

- [x] PR: Based on a correct branch
- [ ] PR: Head branch is rebased on the base branch
- [x] PR: Assignee chosen and necessary labels are set
- [x] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [x] PR: Checked for spelling, grammar and typos
- [x] JS: There's no errors/warnings in the browser dev console
- [x] Layout: Tested with various content amounts
- [ ] Docs: All the important changes and features are described
- [ ] Tests: Configuration files are checked at test repositories
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [x] Tests: Existing unit tests passed successfully
- [ ] Tests: Existing E2E tests passed successfully
- [x] Tests: Manually tested on personal instance

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve
