### PR TITLE
[VEGA-4998]: Style fixes

### DIFF
--- a/src/components/Helpers/ContextMenuHelper.tsx
+++ b/src/components/Helpers/ContextMenuHelper.tsx
@@ -250,9 +250,7 @@ export const VerticalMoreContextMenu: React.FC<Props> = ({
         aria-hidden="true"
       >
         <div>{title}</div>
-        <span className="vertical__more">
           <SvgMoreVertical />
-        </span>
       </div>
 
       {isOpenContextMenu && (

--- a/src/components/Histograms/HistogramComponent.tsx
+++ b/src/components/Histograms/HistogramComponent.tsx
@@ -179,7 +179,7 @@ export const HistogramComponent: React.FC<Props> = ({ grid }) => {
   );
 
   const topContent =
-    histogramsPayload?.length > 0 ? (
+    histogramsPayload?.length ? (
       <div>
         <div>
           <VerticalMoreContextMenu

--- a/src/components/SensitiveAnalysis/SensitiveAnalysisComponent.css
+++ b/src/components/SensitiveAnalysis/SensitiveAnalysisComponent.css
@@ -3,13 +3,16 @@
   width: 100%;
 
   &__title {
-    display: flex;
-    justify-content: space-between;
+    display: inline-block;
     font-size: 18px;
     font-weight: 400;
     line-height: 21px;
     cursor: pointer;
+    user-select: none;
     color: var(--color-typo-primary);
+    &--statistic {
+       cursor: initial;
+    }
   }
 
   &__content {

--- a/src/components/SensitiveAnalysis/SensitiveAnalysisComponent.tsx
+++ b/src/components/SensitiveAnalysis/SensitiveAnalysisComponent.tsx
@@ -145,7 +145,7 @@ export const SensitiveAnalysisComponent: React.FC<Props> = ({ sidebarRow }) => {
   const statistic = (
     <div className="sensitive-analysis">
       <div>
-        <div className="sensitive-analysis__title">Статистика</div>
+        <div className="sensitive-analysis__title sensitive-analysis__title--statistic">Статистика</div>
 
         {isLoadingStatistic || !sensitiveAnalysisStatisticData ? (
           <Loader />


### PR DESCRIPTION
## Problem statement
https://artcpt.atlassian.net/browse/VEGA-4998

## Solution details
- удален образовавшийся отступ около троеточий в гистограмме
- курсор руки восстановлен до начального его значения в модалке анализа по некликабельному заголовку "Статистика"
- убрана возможность клика на всю ширину окна у заголовка "Анализ чувствительности"

## Type

- [ ] Feature
- [x] Bug Fix
- [ ] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

## Quality control

- [x] PR: Based on a correct branch
- [x] PR: Head branch is rebased on the base branch
- [x] PR: Assignee chosen and necessary labels are set
- [x] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [x] PR: Checked for spelling, grammar and typos
- [x] JS: There's no errors/warnings in the browser dev console
- [x] Layout: Tested with various content amounts
- [ ] Docs: All the important changes and features are described
- [ ] Tests: Configuration files are checked at test repositories
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [ ] Tests: Existing unit tests passed successfully
- [ ] Tests: Existing E2E tests passed successfully
- [ ] Tests: Manually tested on personal instance

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve
