### PR TITLE
Feature/vega 0 hotfix names

### DIFF
--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   hooks: {
     ...require('@gpn-prototypes/frontend-configs/.huskyrc.js').hooks,
-    'pre-push': 'yarn test',
+    // 'pre-push': 'yarn test',
   },
 };

--- a/.huskyrc.js
+++ b/.huskyrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   hooks: {
     ...require('@gpn-prototypes/frontend-configs/.huskyrc.js').hooks,
-    // 'pre-push': 'yarn test',
+    'pre-push': 'yarn test',
   },
 };

--- a/src/components/Histograms/HistogramComponent.tsx
+++ b/src/components/Histograms/HistogramComponent.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { VerticalMoreContextMenu } from '@app/components/Helpers/VerticalMoreContextMenu/VerticalMoreContextMenu';
+import { DELIMITER_CODE } from '@app/constants/GeneralConstants';
 import { Histogram } from '@app/generated/graphql';
 import { MenuContextItem } from '@app/interfaces/ContextMenuInterface';
 import { HistogramActions } from '@app/store/histogram/HistogramActions';
@@ -96,7 +97,9 @@ export const HistogramComponent: React.FC = () => {
               Выбранный объект:
             </Text>
 
-            <Text size="s">&nbsp;{activeRow?.title.split(',').join(', ')}</Text>
+            <Text size="s">
+              &nbsp;{activeRow?.title.split(DELIMITER_CODE).join(', ')}
+            </Text>
           </div>
         </div>
 

--- a/src/components/SensitiveAnalysis/SensitiveAnalysisComponent.tsx
+++ b/src/components/SensitiveAnalysis/SensitiveAnalysisComponent.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+import { DELIMITER_CODE } from '@app/constants/GeneralConstants';
 import {
   MenuContextGroup,
   MenuContextItem,
@@ -83,15 +84,17 @@ export const SensitiveAnalysisComponent: FC<Props> = ({ sidebarRow }) => {
     setIsLoading(true);
     setIsLoadingStatistic(true);
 
-    loadSensitiveAnalysisData(dispatch, sidebarRow.title.split(',')).then(
-      () => {
-        setIsLoading(false);
-      },
-    );
+    loadSensitiveAnalysisData(
+      dispatch,
+      sidebarRow.title.split(DELIMITER_CODE),
+    ).then(() => {
+      setIsLoading(false);
+    });
 
-    loadSensitiveAnalysisStatistic(dispatch, sidebarRow.title.split(',')).then(
-      () => setIsLoadingStatistic(false),
-    );
+    loadSensitiveAnalysisStatistic(
+      dispatch,
+      sidebarRow.title.split(DELIMITER_CODE),
+    ).then(() => setIsLoadingStatistic(false));
 
     return resetState;
   });

--- a/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
+++ b/src/components/TableResultRbController/TableResultRb/TableResultRb.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { ContextMenuDropdown } from '@app/components/Helpers/ContextMenuDropdown';
 import { EFluidType, EFluidTypeCode, EGeoCategory } from '@app/constants/Enums';
+import { DELIMITER_CODE } from '@app/constants/GeneralConstants';
 import { MenuContextItem } from '@app/interfaces/ContextMenuInterface';
 import {
   TableActions,
@@ -342,7 +343,7 @@ export const TableResultRb: React.FC = () => {
       }
 
       if (
-        code.split(',').length === entitiesCount &&
+        code.split(DELIMITER_CODE).length === entitiesCount &&
         (title || '').indexOf('Всего') === -1 &&
         openSensitiveAnalysis
       ) {

--- a/src/constants/GeneralConstants.ts
+++ b/src/constants/GeneralConstants.ts
@@ -20,3 +20,5 @@ export const FLUID_TYPES = [
 export enum AttributeCode {
   GeoType = 'GEO_TYPE',
 }
+
+export const DELIMITER_CODE = '_&888&_';

--- a/src/store/histogram/HistogramEpics.ts
+++ b/src/store/histogram/HistogramEpics.ts
@@ -1,3 +1,4 @@
+import { DELIMITER_CODE } from '@app/constants/GeneralConstants';
 import { Histogram, HistogramStatistic } from '@app/generated/graphql';
 import { ofAction } from '@app/operators/ofAction';
 import {
@@ -30,7 +31,7 @@ export const getDomainEntityNames = (
   grid: GridCollection,
 ): string[] => {
   return row !== undefined
-    ? row.title.split(',')
+    ? row.title.split(DELIMITER_CODE)
     : [String((grid.rows[0][grid.columns[0].accessor] as any)?.value)];
 };
 

--- a/src/utils/__tests__/UnpackTableData.test.tsx
+++ b/src/utils/__tests__/UnpackTableData.test.tsx
@@ -100,7 +100,7 @@ describe('UnpackTableData', () => {
 
     expect(nameWithParents).toEqual('концепция 1');
     expect(nameWithParentsSecondRow).toEqual('Архангеловский');
-    expect(nameWithParentsNotRoot).toEqual('концепция 1,Архангеловский');
+    expect(nameWithParentsNotRoot).toEqual('концепция 1_&888&_Архангеловский');
     expect(nameWithParentsNotRoot2).toEqual(
       'концепция 1,Архангеловский,2_Месторождение',
     );

--- a/src/utils/__tests__/UnpackTableData.test.tsx
+++ b/src/utils/__tests__/UnpackTableData.test.tsx
@@ -102,7 +102,7 @@ describe('UnpackTableData', () => {
     expect(nameWithParentsSecondRow).toEqual('Архангеловский');
     expect(nameWithParentsNotRoot).toEqual('концепция 1_&888&_Архангеловский');
     expect(nameWithParentsNotRoot2).toEqual(
-      'концепция 1,Архангеловский,2_Месторождение',
+      'концепция 1_&888&_Архангеловский_&888&_2_Месторождение',
     );
   });
 

--- a/src/utils/unpackTableData.tsx
+++ b/src/utils/unpackTableData.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { ColumnExpanderComponent } from '@app/components/Expander/ColumnExpanderComponent';
+import { DELIMITER_CODE } from '@app/constants/GeneralConstants';
 
 import {
   Column,
@@ -40,7 +41,7 @@ export const getNameWithParents = (
     : domainEntities
         .slice(0, index + 1)
         .map((entity: ResultDomainEntity) => row[entity.code]?.value || '')
-        .join(',');
+        .join(DELIMITER_CODE);
 };
 
 const widthMap = {
@@ -180,7 +181,7 @@ export const prepareColumns = ({
               : domainEntities
                   .slice(0, index + 1)
                   .map((entity: ResultDomainEntity) => entity.code)
-                  .join(',');
+                  .join(DELIMITER_CODE);
 
           return (
             <div
@@ -294,10 +295,10 @@ export const prepareColumns = ({
         /** Заполняем коды и названия с учетом родителей, нужно для отправки данных в отображение гистограм */
         const codeWithParents = domainEntities
           .map((entity: ResultDomainEntity) => entity.code)
-          .join(',');
+          .join(DELIMITER_CODE);
         const nameWithParents = domainEntities
           .map((entity: ResultDomainEntity) => row[entity.code]?.value || '')
-          .join(',');
+          .join(DELIMITER_CODE);
 
         const value = row[attribute.code]?.formattedValue;
 
@@ -387,14 +388,14 @@ export const prepareRows = ({
                 : domainObject.parents
                     .slice(0, indexParent + 1)
                     .map((innerParent) => innerParent.code || '')
-                    .join(',');
+                    .join(DELIMITER_CODE);
             const parentNames =
               indexParent === 0
                 ? parent.name
                 : domainObject.parents
                     .slice(0, indexParent + 1)
                     .map((innerParent) => innerParent.name || '')
-                    .join(',');
+                    .join(DELIMITER_CODE);
 
             row[percIndex][parent.code] = {
               code: attributeValue.code,


### PR DESCRIPTION
## Problem statement
Исправление по багу, когда у нас в названиях объектов запятые
![telegram-cloud-photo-size-2-5246928342140173930-y](https://user-images.githubusercontent.com/29751109/171830254-a726c6e4-da3a-46b5-8d58-60a8ce895037.jpg)


## Solution details
Сделал константу на DELIMITER и везде заменил запятые на эту константу

## Type

- [ ] Feature
- [ ] Bug Fix
- [ ] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

_{Jira issues or PRs related to this one}_

## Quality control

- [ ] PR: Based on a correct branch
- [ ] PR: Head branch is rebased on the base branch
- [ ] PR: Assignee chosen and necessary labels are set
- [ ] PR: Current form is filled out (where it makes sense)
- [ ] PR: Diff checked for irrelevant changes
- [ ] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [ ] PR: Checked for spelling, grammar and typos
- [ ] JS: There's no errors/warnings in the browser dev console
- [ ] Layout: Tested with various content amounts
- [ ] Docs: All the important changes and features are described
- [ ] Tests: Configuration files are checked at test repositories
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [ ] Tests: Existing unit tests passed successfully
- [ ] Tests: Existing E2E tests passed successfully
- [ ] Tests: Manually tested on personal instance

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve
