### PR TITLE
[VEGA-5138] notification with current progressBar if closing archive

### DIFF
--- a/src/components/DownloadResultModal/CancelModeContent/CancelModeContent.tsx
+++ b/src/components/DownloadResultModal/CancelModeContent/CancelModeContent.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { FileAction } from '@app/store/file/fileActions';
+import { FileActions } from '@app/store/file/fileActions';
 import { RootState } from '@app/store/types';
 import { Button } from '@consta/uikit/Button';
 import { IconClose } from '@consta/uikit/IconClose';
@@ -29,7 +29,7 @@ export const CancelModeContent: React.FC<ModalContentProps> = ({
   /** Callbacks */
   const cancelFetch = useCallback(() => {
     if (isLoading) {
-      dispatch(FileAction.stopFetchingFile());
+      dispatch(FileActions.stopFetchingFile());
     }
   }, [dispatch, isLoading]);
 

--- a/src/components/DownloadResultModal/DownloadResultModal.tsx
+++ b/src/components/DownloadResultModal/DownloadResultModal.tsx
@@ -1,10 +1,7 @@
-import React, { FC, useCallback, useEffect } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { LoaderAction } from '@app/store/loader/loaderActions';
-import { NotifyActions } from '@app/store/notify/notifyActions';
+import React, { FC, useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { RootState } from '@app/store/types';
 import { Modal } from '@consta/uikit/Modal';
-import { SnackBarItemDefault } from '@consta/uikit/SnackBar';
 import { block } from 'bem-cn';
 
 import { CancelModeContent } from './CancelModeContent/CancelModeContent';
@@ -14,7 +11,7 @@ import { ModalContentProps, ModalMode } from './ModalContentType';
 
 import './DownloadResultModal.css';
 
-export const cn = block('DownloadResultModal');
+const cn = block('DownloadResultModal');
 
 interface Props {
   handleClose: () => void;
@@ -32,53 +29,26 @@ const modalConfig: ModalConfig = {
   cancel: CancelModeContent,
 };
 
-export const DownloadResultModal: React.FC<Props> = ({ handleClose }) => {
+export const DownloadResultModal: FC<Props> = ({ handleClose }) => {
   /** Store */
-  const dispatch = useDispatch();
-
   const isLoaded: boolean = useSelector(
     ({ loader }: RootState): boolean => loader.loaded.file || false,
   );
 
   /** State */
-  const [mode, setMode] = React.useState<ModalMode>(ModalMode.initial);
-  const [isFileLarge, setIsFileLarge] = React.useState<boolean>(false);
-
-  /** Callbacks */
-  const showNotification = useCallback(
-    (item: SnackBarItemDefault) => dispatch(NotifyActions.appendItem(item)),
-    [dispatch],
-  );
-  const hideNotification = useCallback(
-    (id: string) => dispatch(NotifyActions.removeItem(id)),
-    [dispatch],
-  );
-
-  /** Effects */
-  useEffect(() => {
-    return () => {
-      dispatch(LoaderAction.resetType('file'));
-    };
-  }, [dispatch]);
+  const [mode, setMode] = useState<ModalMode>(ModalMode.initial);
+  const [isFileLarge, setIsFileLarge] = useState<boolean>(false);
 
   /**
    * Подписываемся на состояние загрузки:
    * когда файл загружен,
-   * закрываем модалку и показываем нотификацию
+   * закрываем модалку
    * */
   useEffect(() => {
     if (isLoaded) {
       handleClose();
-
-      showNotification({
-        key: 'success',
-        message: 'Файл расчёта сохранён на компьютер',
-        status: 'success',
-        onClose: () => hideNotification('success'),
-        autoClose: 5,
-      });
     }
-  }, [isLoaded, handleClose, showNotification, hideNotification]);
+  }, [handleClose, isLoaded]);
 
   const ContentComponent = modalConfig[mode];
 

--- a/src/components/DownloadResultModal/InitialModeContent/InitialModeContent.tsx
+++ b/src/components/DownloadResultModal/InitialModeContent/InitialModeContent.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState } from 'react';
 import { useDispatch } from 'react-redux';
-import { FileAction } from '@app/store/file/fileActions';
+import { FileActions } from '@app/store/file/fileActions';
 import { Button } from '@consta/uikit/Button';
 import { Checkbox } from '@consta/uikit/Checkbox';
 import { IconClose } from '@consta/uikit/IconClose';
@@ -66,7 +66,7 @@ export const InitialModeContent: React.FC<ModalContentProps> = ({
   const downloadResult = (): void => {
     try {
       dispatch(
-        FileAction.fetchResultFile({
+        FileActions.fetchResultFile({
           statistics: checkedState[DownloadTypeEnum.Statistics],
           samples: checkedState[DownloadTypeEnum.Samples],
           plots: checkedState[DownloadTypeEnum.Plots],

--- a/src/store/file/fileActions.ts
+++ b/src/store/file/fileActions.ts
@@ -11,12 +11,21 @@ export type FetchFilePayload = {
 export type FileStore = {
   status: string;
   websocketId: string;
+  downloadArchiveModal: ModalMode;
 };
 
-export const FileAction = {
+export type ModalMode = {
+  isClosed: boolean;
+  allowNotifications?: boolean;
+};
+
+export const FileActions = {
   fetchResultFile: factory<FetchFilePayload>('FETCH_RESULT_FILE'),
   stopFetchingFile: factory('STOP_FETCHING_FILE'),
   fetchResultFileFulfilled: factory('FETCH_FILE_SUCCESS'),
-  setFileStatus: factory<string>('FILE/SET_FILE_STATUS'),
-  setWebsocketId: factory<string>('FILE/SET_WEBSOCKET_ID'),
+  setFileStatus: factory<string>('SET_FILE_STATUS'),
+  setWebsocketId: factory<string>('SET_WEBSOCKET_ID'),
+  setDownloadArchiveModalMode: factory<ModalMode>(
+    'SET_IS_CLOSED_DOWNLOAD_ARCHIVE_MODAL',
+  ),
 };

--- a/src/store/file/fileReducers.ts
+++ b/src/store/file/fileReducers.ts
@@ -1,24 +1,35 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 
-import { FileAction, FileStore } from './fileActions';
+import { FileActions, FileStore, ModalMode } from './fileActions';
 
 export const loaderStoreInitialState: FileStore = {
   status: '',
   websocketId: '',
+  downloadArchiveModal: { isClosed: true, allowNotifications: true },
 };
 
 export const FileReducers = reducerWithInitialState<FileStore>(
   loaderStoreInitialState,
 )
-  .case(FileAction.setFileStatus, (state, status: string) => {
+  .case(FileActions.setFileStatus, (state, status: string) => {
     return {
       ...state,
       status,
     };
   })
-  .case(FileAction.setWebsocketId, (state, websocketId: string) => {
+  .case(FileActions.setWebsocketId, (state, websocketId: string) => {
     return {
       ...state,
       websocketId,
     };
-  });
+  })
+
+  .case(
+    FileActions.setDownloadArchiveModalMode,
+    (state, payload: ModalMode) => {
+      return {
+        ...state,
+        downloadArchiveModal: payload,
+      };
+    },
+  );

--- a/src/store/histogram/HistogramEpics.ts
+++ b/src/store/histogram/HistogramEpics.ts
@@ -18,7 +18,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 
-import { LoaderAction } from '../loader/loaderActions';
+import { LoaderActions } from '../loader/loaderActions';
 import { TableActions } from '../table/tableActions';
 import { tableActiveRowSelector } from '../table/TableSelectors';
 import { RootState, StoreDependencies } from '../types';
@@ -92,7 +92,7 @@ const loadHistogramEpic: Epic<
     ofAction(TableActions.setActiveRow, HistogramActions.setNumberOfRows),
     withLatestFrom(statePairs$),
     filter(() => state$.value.settings.showHistogram),
-    tap(() => dispatch(LoaderAction.setLoading('histogram'))),
+    tap(() => dispatch(LoaderActions.setLoading('histogram'))),
     distinctUntilChanged(),
     switchMap(([{ payload }, [oldState, newState]]) => {
       toggleActiveTableCellClass(newState, oldState);
@@ -119,7 +119,7 @@ const loadHistogramEpic: Epic<
     tap((histograms: Histogram[]) =>
       dispatch(HistogramActions.setHistograms(histograms)),
     ),
-    tap(() => dispatch(LoaderAction.setLoaded('histogram'))),
+    tap(() => dispatch(LoaderActions.setLoaded('histogram'))),
     ignoreElements(),
   );
 };
@@ -132,7 +132,7 @@ const loadHistogramStatisticEpic: Epic<
 > = (action$, state$, { dispatch }) =>
   action$.pipe(
     ofAction(HistogramActions.loadStatistic, TableActions.setActiveRow),
-    tap(() => dispatch(LoaderAction.setLoading('histogram-statistic'))),
+    tap(() => dispatch(LoaderActions.setLoading('histogram-statistic'))),
     filter(() => state$.value.histogram.isShowStatistic),
     switchMap(() => {
       return from(
@@ -148,7 +148,7 @@ const loadHistogramStatisticEpic: Epic<
     tap((statistics: HistogramStatistic[]) =>
       dispatch(HistogramActions.setStatistics(statistics)),
     ),
-    tap(() => dispatch(LoaderAction.setLoaded('histogram-statistic'))),
+    tap(() => dispatch(LoaderActions.setLoaded('histogram-statistic'))),
     ignoreElements(),
   );
 

--- a/src/store/history/HistoryEpics.ts
+++ b/src/store/history/HistoryEpics.ts
@@ -12,7 +12,7 @@ import { Action } from 'typescript-fsa';
 
 import { GeneralActions } from '../general/generalActions';
 import { HistogramActions } from '../histogram/HistogramActions';
-import { LoaderAction } from '../loader/loaderActions';
+import { LoaderActions } from '../loader/loaderActions';
 import { NotifyActions } from '../notify/notifyActions';
 import { SettingsActions } from '../settings/settingsActions';
 import { TableActions } from '../table/tableActions';
@@ -52,7 +52,7 @@ const handleChangeLocationEpic: Epic<
       dispatch(treeDuck.actions.resetState());
       dispatch(TableActions.resetState());
       dispatch(HistogramActions.resetState());
-      dispatch(LoaderAction.resetStore());
+      dispatch(LoaderActions.resetStore());
     }),
     ignoreElements(),
   );

--- a/src/store/loader/loaderActions.ts
+++ b/src/store/loader/loaderActions.ts
@@ -20,7 +20,7 @@ export interface LoaderStore {
   loading: LoadingKeyValue;
 }
 
-export const LoaderAction = {
+export const LoaderActions = {
   setLoaded: factory<LoadingType>('SET_LOADED'),
   setLoading: factory<LoadingType>('SET_LOADING'),
   resetStore: factory('RESET_STORE'),

--- a/src/store/loader/loaderReducers.ts
+++ b/src/store/loader/loaderReducers.ts
@@ -1,6 +1,6 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 
-import { LoaderAction, LoaderStore, LoadingType } from './loaderActions';
+import { LoaderActions, LoaderStore, LoadingType } from './loaderActions';
 
 export const loaderStoreInitialState: LoaderStore = Object.freeze({
   loaded: {
@@ -22,7 +22,7 @@ export const loaderStoreInitialState: LoaderStore = Object.freeze({
 export const LoaderReducers = reducerWithInitialState<LoaderStore>(
   loaderStoreInitialState,
 )
-  .case(LoaderAction.setLoading, (state, type: LoadingType) => {
+  .case(LoaderActions.setLoading, (state, type: LoadingType) => {
     const cloneState = { ...state };
 
     cloneState.loaded[type] = false;
@@ -30,7 +30,7 @@ export const LoaderReducers = reducerWithInitialState<LoaderStore>(
 
     return cloneState;
   })
-  .case(LoaderAction.setLoaded, (state, type: LoadingType) => {
+  .case(LoaderActions.setLoaded, (state, type: LoadingType) => {
     const cloneState = { ...state };
 
     cloneState.loaded[type] = true;
@@ -38,7 +38,7 @@ export const LoaderReducers = reducerWithInitialState<LoaderStore>(
 
     return cloneState;
   })
-  .case(LoaderAction.resetType, (state, type: LoadingType) => {
+  .case(LoaderActions.resetType, (state, type: LoadingType) => {
     const cloneState = { ...state };
 
     cloneState.loaded[type] = false;
@@ -46,7 +46,7 @@ export const LoaderReducers = reducerWithInitialState<LoaderStore>(
 
     return cloneState;
   })
-  .case(LoaderAction.resetStore, () => {
+  .case(LoaderActions.resetStore, () => {
     return {
       loaded: {
         'file': false,

--- a/src/store/table/TableEpics.ts
+++ b/src/store/table/TableEpics.ts
@@ -14,7 +14,7 @@ import {
   tap,
 } from 'rxjs/operators';
 
-import { LoaderAction } from '../loader/loaderActions';
+import { LoaderActions } from '../loader/loaderActions';
 import { RootState, StoreDependencies } from '../types';
 
 import { TableActions } from './tableActions';
@@ -27,7 +27,7 @@ const handleInitLoadTableEpic: Epic<
 > = (action$, state$, { dispatch, projectService }) => {
   return action$.pipe(
     ofAction(TableActions.initLoadTable),
-    tap(() => dispatch(LoaderAction.setLoading('table'))),
+    tap(() => dispatch(LoaderActions.setLoading('table'))),
     distinctUntilChanged(),
     switchMap(() => {
       return zip(from(loadTableData()), from(loadDecimalData()));
@@ -56,7 +56,7 @@ const handleInitLoadTableEpic: Epic<
         }
       },
     ),
-    tap(() => dispatch(LoaderAction.setLoaded('table'))),
+    tap(() => dispatch(LoaderActions.setLoaded('table'))),
     ignoreElements(),
   );
 };
@@ -75,7 +75,7 @@ const handleSetDecimalEpic: Epic<
 > = (action$, state$, { dispatch }) => {
   return action$.pipe(
     ofAction(TableActions.initUpdateDecimalFixed),
-    tap(() => dispatch(LoaderAction.setLoading('decimal'))),
+    tap(() => dispatch(LoaderActions.setLoading('decimal'))),
     distinctUntilChanged(),
     switchMap(({ payload }) => {
       let currentDecimal = state$.value.table.decimalFixed[payload.columnCode];
@@ -93,7 +93,7 @@ const handleSetDecimalEpic: Epic<
     }),
     tap(() => {
       dispatch(TableActions.updateDecimal());
-      dispatch(LoaderAction.setLoaded('decimal'));
+      dispatch(LoaderActions.setLoaded('decimal'));
     }),
     ignoreElements(),
   );

--- a/src/store/websocket/epics/sendWebsocketEpic.ts
+++ b/src/store/websocket/epics/sendWebsocketEpic.ts
@@ -4,7 +4,7 @@ import { AnyAction } from 'redux';
 import { Epic } from 'redux-observable';
 import { ignoreElements, tap } from 'rxjs/operators';
 
-import { WebsocketAction } from '../websocketActions';
+import { WebsocketActions } from '../websocketActions';
 
 function isNotClose(websocket: WebSocket): boolean {
   return websocket.readyState !== 3 && websocket.readyState !== 2;
@@ -17,7 +17,7 @@ export const handleSendWebsocketEpic: Epic<
   StoreDependencies
 > = (action$, state$) =>
   action$.pipe(
-    ofAction(WebsocketAction.sendMessage),
+    ofAction(WebsocketActions.sendMessage),
     tap(({ payload }) => {
       const currentWebsocket: WebSocket | undefined =
         state$.value.websocket.instance[payload.id];

--- a/src/store/websocket/websocketActions.ts
+++ b/src/store/websocket/websocketActions.ts
@@ -27,8 +27,8 @@ export interface WebsocketStore {
   instance: WebsocketKeyValue;
 }
 
-export const WebsocketAction = {
-  setWebsocket: factory<WebsocketPayload>('WEBSOCKET/SET_WEBSOCKET'),
-  handleMessage: factory<HandleMessagePayload>('WEBSOCKET/HANDLE_MESSAGE'),
-  sendMessage: factory<SendMessagePayload>('WEBSOCKET/SEND_MESSAGE'),
+export const WebsocketActions = {
+  setWebsocket: factory<WebsocketPayload>('SET_WEBSOCKET'),
+  handleMessage: factory<HandleMessagePayload>('HANDLE_MESSAGE'),
+  sendMessage: factory<SendMessagePayload>('SEND_MESSAGE'),
 };

--- a/src/store/websocket/websocketReducers.ts
+++ b/src/store/websocket/websocketReducers.ts
@@ -1,7 +1,7 @@
 import { reducerWithInitialState } from 'typescript-fsa-reducers';
 
 import {
-  WebsocketAction,
+  WebsocketActions,
   WebsocketKeyValue,
   WebsocketPayload,
   WebsocketStore,
@@ -13,7 +13,7 @@ export const websocketStoreInitialState: WebsocketStore = {
 
 export const WebsocketReducers = reducerWithInitialState<WebsocketStore>(
   websocketStoreInitialState,
-).case(WebsocketAction.setWebsocket, (state, payload: WebsocketPayload) => {
+).case(WebsocketActions.setWebsocket, (state, payload: WebsocketPayload) => {
   const cloneState = { ...state };
 
   cloneState.instance[payload.id] = payload.websocket;

--- a/src/utils/websocketHelper.ts
+++ b/src/utils/websocketHelper.ts
@@ -2,7 +2,7 @@ import projectService from '@app/services/ProjectService';
 import { isSecureBaseApiUrl } from '@app/services/utils';
 import {
   HandleMessagePayload,
-  WebsocketAction,
+  WebsocketActions,
 } from '@app/store/websocket/websocketActions';
 import {
   WebsocketDomain,
@@ -37,7 +37,7 @@ export async function createWebsocket({
 
   if (ws) {
     dispatch(
-      WebsocketAction.setWebsocket({
+      WebsocketActions.setWebsocket({
         id,
         websocket: ws,
       }),
@@ -54,7 +54,7 @@ export async function createWebsocket({
 
   ws.onmessage = (event) => {
     dispatch(
-      WebsocketAction.handleMessage({
+      WebsocketActions.handleMessage({
         id,
         message: JSON.parse(event.data),
       }),


### PR DESCRIPTION
Если в процессе генерации архива кликнуть на любую область экрана мышкой. Попап с лоадером скрывается. Пользователю не ясно что происходит с системой в этот момент.

https://artcpt.atlassian.net/browse/VEGA-5138

1)Появляется плашка с указанием динамики процесса выгрузки если закрыть модал до полного скачивания архива
2) Зарефакторены некоторые вещи(например NotifyAction было вместо NotifyActions и прочее по мелочи)

## Type
- [x] Feature
- [x] Bug Fix
- [x] Refactoring
- [ ] Test
- [ ] Other

## Associated issues

_{Jira issues or PRs related to this one}_

## Quality control

- [x] PR: Based on a correct branch
- [x] PR: Head branch is rebased on the base branch
- [x] PR: Assignee chosen and necessary labels are set
- [x] PR: Current form is filled out (where it makes sense)
- [x] PR: Diff checked for irrelevant changes
- [x] PR: Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) specs
- [x] PR: Checked for spelling, grammar and typos
- [x] JS: There's no errors/warnings in the browser dev console
- [x] Layout: Tested with various content amounts
- [ ] Docs: All the important changes and features are described
- [ ] Tests: Configuration files are checked at test repositories
- [ ] Tests: New unit tests developed
- [ ] Tests: New E2E tests developed
- [x] Tests: Existing unit tests passed successfully
- [ ] Tests: Existing E2E tests passed successfully
- [x] Tests: Manually tested on personal instance

## Notable statements
- [ ] Affects configuration files
- [ ] Brings new packages or updates existing
- [ ] Opened follow-up tasks to resolve
